### PR TITLE
Fix missing libquadmath

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -28,7 +28,7 @@ ctng_vendor:
 #ctng_duma:
 #  - 2.5.15
 ctng_gcc_build_number:
-  - 12
+  - 13
 ctng_gmp:
   - 6.1.2
 ctng_isl:

--- a/recipe/install-gcc.sh
+++ b/recipe/install-gcc.sh
@@ -237,7 +237,7 @@ popd
 
 # make links to libs in the sysroot
 for lib in libstdc++ libgfortran libatomic libquadmath libitm libvtv lib{a,l,ub,t}san; do
-  ln -s ${PREFIX}/lib/${lib}.so ${PREFIX}/${CHOST}/sysroot/lib/${lib}.so
+  ln -s ${PREFIX}/lib/${lib}.so* ${PREFIX}/${CHOST}/sysroot/lib/
 done
 
 source ${RECIPE_DIR}/make_tool_links.sh


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
