### PR TITLE
Fix _openmp_mutex

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -351,12 +351,12 @@ outputs:
         - {{ pin_subpackage('libgomp', exact=True) }}
       run:
         - _libgcc_mutex {{ _libgcc_mutex }}  # [linux64 or ppc64le]
-        - {{ pin_subpackage("libgomp", max_pin=None) }}
+        - libgomp >=7.5.0
       run_constrained:
         # conflict with previous name
         - openmp_impl 9999
     build:
-      string: 0_gnu
+      string: 1_gnu
       skip: True   # [target_platform != ctng_target_platform]
       run_exports:
         strong:


### PR DESCRIPTION
Since we are building multiple versions, let's make the lower bound
equal to the lowest version that we build

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
