### PR TITLE
fix not proper rpath for libgfortran's .so files

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -41,7 +41,7 @@ ctng_vendor:
 #ctng_duma:
 #  - 2.5.15
 ctng_gcc_build_number:
-  - 18
+  - 19
 ctng_gmp:
   - 6.1.2
 ctng_isl:

--- a/recipe/install-libgfortran.sh
+++ b/recipe/install-libgfortran.sh
@@ -11,6 +11,8 @@ rm -f ${PREFIX}/lib/libgfortran* || true
 
 cp -f --no-dereference ${SRC_DIR}/gcc_built/${CHOST}/sysroot/lib/libgfortran*.so* ${PREFIX}/lib/
 
+patchelf --set-rpath '$ORIGIN' ${PREFIX}/lib/libgfortran*.so*
+
 # Install Runtime Library Exception
 install -Dm644 $SRC_DIR/.build/src/gcc-${PKG_VERSION}/COPYING.RUNTIME \
         ${PREFIX}/share/licenses/libgfortran/RUNTIME.LIBRARY.EXCEPTION


### PR DESCRIPTION
The current libgfortran*.so* files are containing still a rpath to their original _build_env.  So we need to do the same as we do for libstdc++*.so* files.