### PR TITLE
fix compiler option -static

### DIFF
--- a/recipe/install-libgcc.sh
+++ b/recipe/install-libgcc.sh
@@ -35,9 +35,10 @@ popd
 
 mkdir -p ${PREFIX}/lib
 
-# no static libs
-find ${PREFIX}/${CHOST}/lib -name "*\.a" -exec rm -rf {} \;
-# no libtool files
+# we can't remove static base libraries, as it would make option -static not working
+# and things like qt won't build anymore.
+# find ${PREFIX}/${CHOST}/lib -name "*\.a" -exec rm -rf {} \;
+# neverhteless we want no libtool files
 find ${PREFIX}/${CHOST}/lib -name "*\.la" -exec rm -rf {} \;
 
 if [[ "${PKG_NAME}" != gcc_impl* ]]; then

--- a/recipe/install-libstdc++.sh
+++ b/recipe/install-libstdc++.sh
@@ -18,9 +18,11 @@ mv ${PREFIX}/${CHOST}/lib/* ${PREFIX}/lib
 
 patchelf --set-rpath '$ORIGIN' ${PREFIX}/lib/libstdc++.so
 
-# no static libs
-find ${PREFIX}/lib -name "*\.a" -exec rm -rf {} \;
-# no libtool files
+# we can't get rid of static libraries as this would lead to not working -static
+# option, which prevents then proper build we can't get rid of static libraries as this would lead to not working -static
+# option, which prevents then proper build from build-tools of qt
+# find ${PREFIX}/lib -name "*\.a" -exec rm -rf {} \;
+# nevertheless we want no libtool files
 find ${PREFIX}/lib -name "*\.la" -exec rm -rf {} \;
 
 # Install Runtime Library Exception


### PR DESCRIPTION
Current compiler disables -static by removing its basic static libraries for libgcc (which is in many aspects not good, even for shared versions), and libstdc++.  This leads to two facts:
1. we have a broken compiler, which lacks basic feature.
2. projects using static option for their build tools are failing to build. Most prominent project is as example qt

I agree that we don't want to encourage users to build static libraries, but we shouldn't ship here broken compilers for that.  A better solution would be to specify in activation explicit a gcc spec file, which disables the usage of static in general.
