### PR TITLE
Remove unnecessary hack for reading specs

### DIFF
--- a/recipe/install-gfortran.sh
+++ b/recipe/install-gfortran.sh
@@ -38,21 +38,6 @@ install -Dm644 $SRC_DIR/build-finclude/$PREFIX/lib/gcc/${CHOST}/${gcc_version}/f
 install -Dm644 $SRC_DIR/COPYING.RUNTIME \
         ${PREFIX}/share/licenses/gcc-fortran/RUNTIME.LIBRARY.EXCEPTION
 
-# generate specfile so that we can patch loader link path
-# link_libgcc should have the gcc's own libraries by default (-R)
-# so that LD_LIBRARY_PATH isn't required for basic libraries.
-#
-# GF method here to create specs file and edit it.  The other methods
-# tried had no effect on the result.  including:
-#   setting LINK_LIBGCC_SPECS on configure
-#   setting LINK_LIBGCC_SPECS on make
-#   setting LINK_LIBGCC_SPECS in gcc/Makefile
-specdir=${PREFIX}/lib/gcc/${CHOST}/${gcc_version}
-mv $PREFIX/bin/${CHOST}-gfortran $PREFIX/bin/${CHOST}-gfortran.bin
-echo '#!/bin/sh' > $PREFIX/bin/${CHOST}-gfortran
-echo $PREFIX/bin/${CHOST}-gfortran.bin -specs=$specdir/specs '"$@"' >> $PREFIX/bin/${CHOST}-gfortran
-chmod +x $PREFIX/bin/${CHOST}-gfortran
-
 set +x
 # Strip executables, we may want to install to a different prefix
 # and strip in there so that we do not change files that are not

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "gcc_impl" %}
 {% set version = gcc_version %}
 {% set chost = gcc_machine ~ "-" ~ gcc_vendor ~ "-linux-gnu-" %}
-{% set build_num = 6 %}
+{% set build_num = 7 %}
 
 package:
   name: gcc_compilers


### PR DESCRIPTION
The specsdir is the default directory now, so there's no need to
have this hack.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
