### PR TITLE
Add patch that was missed from the 10.4.0 release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = gcc_version %}
 {% set chost = gcc_machine ~ "-" ~ gcc_vendor ~ "-linux-gnu-" %}
-{% set build_num = 18 %}
+{% set build_num = 19 %}
 
 package:
   name: gcc_compilers
@@ -19,6 +19,7 @@ source:
       - patches/0022-cross-compile-older-glibc.patch   # [glibc_version == "2.12" and target_platform != "linux-64"]
       - patches/old-allow-commands-in-main-specfile.patch                      # [gcc_maj_ver < 12]
       - patches/new-allow-commands-in-main-specfile.patch                      # [gcc_maj_ver >= 12]
+      - patches/fix-inconsistent-noexcept-spec.patch                           # [gcc_version == "10.4.0"]
 
 build:
   number: {{ build_num }}

--- a/recipe/patches/fix-inconsistent-noexcept-spec.patch
+++ b/recipe/patches/fix-inconsistent-noexcept-spec.patch
@@ -1,0 +1,38 @@
+From 32bbf76e4345a7961445b86a7cfccffa8a287fc1 Mon Sep 17 00:00:00 2001
+From: Jonathan Wakely <jwakely@redhat.com>
+Date: Fri, 5 Nov 2021 21:42:20 +0000
+Subject: [PATCH] libstdc++: Fix inconsistent noexcept-specific for valarray
+ begin/end
+
+These declarations should be noexcept after I added it to the
+definitions in <valarray>.
+
+libstdc++-v3/ChangeLog:
+
+	* include/bits/range_access.h (begin(valarray), end(valarray)):
+	Add noexcept.
+
+(cherry picked from commit 2b2d97fc545635a0f6aa9c9ee3b017394bc494bf)
+---
+ libstdc++-v3/include/bits/range_access.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libstdc++-v3/include/bits/range_access.h b/libstdc++-v3/include/bits/range_access.h
+index aee72c3fae40b..98c81a153f35a 100644
+--- a/libstdc++-v3/include/bits/range_access.h
++++ b/libstdc++-v3/include/bits/range_access.h
+@@ -104,10 +104,10 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+ 
+   template<typename _Tp> class valarray;
+   // These overloads must be declared for cbegin and cend to use them.
+-  template<typename _Tp> _Tp* begin(valarray<_Tp>&);
+-  template<typename _Tp> const _Tp* begin(const valarray<_Tp>&);
+-  template<typename _Tp> _Tp* end(valarray<_Tp>&);
+-  template<typename _Tp> const _Tp* end(const valarray<_Tp>&);
++  template<typename _Tp> _Tp* begin(valarray<_Tp>&) noexcept;
++  template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
++  template<typename _Tp> _Tp* end(valarray<_Tp>&) noexcept;
++  template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+ 
+   /**
+    *  @brief  Return an iterator pointing to the first element of


### PR DESCRIPTION
In 10.4.0 this patch was missed from the release (it was already in the release branch so I'm not sure how) which causes parsing the headers to fail when used with clang. I've been pinning 10.3.0 where needed but this is starting to get painful and cause conflicts.