### PR TITLE
Backport fix for upstream issue 111413 to GCC13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = gcc_version %}
 {% set chost = gcc_machine ~ "-" ~ gcc_vendor ~ "-linux-gnu-" %}
-{% set build_num = 1 %}
+{% set build_num = 2 %}
 
 package:
   name: gcc_compilers
@@ -16,6 +16,7 @@ source:
       - patches/0022-cross-compile-older-glibc.patch   # [glibc_version == "2.12" and target_platform != "linux-64"]
       - patches/old-allow-commands-in-main-specfile.patch                      # [gcc_maj_ver < 12]
       - patches/new-allow-commands-in-main-specfile.patch                      # [gcc_maj_ver >= 12]
+      - patches/libgomp-support-environ-null.patch                             # [gcc_maj_ver == 13]
 
 build:
   number: {{ build_num }}

--- a/recipe/patches/libgomp-support-environ-null.patch
+++ b/recipe/patches/libgomp-support-environ-null.patch
@@ -1,0 +1,24 @@
+From caf4254c93fbf2e82a973a6c53ca51dcdd65020a Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Fri, 15 Sep 2023 17:22:36 +0200
+Subject: [PATCH] Support case in which environ is NULL
+
+Fix for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111413
+Backport https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=15345980633c502f0486a2e40e96224f49134130
+---
+ libgomp/env.c | 2 +-
+ 1 file changed, 1 insertion(+), 0 deletion(-)
+
+diff --git a/libgomp/env.c b/libgomp/env.c
+index f24484d7f707..8285c65ebb8e 100644
+--- a/libgomp/env.c
++++ b/libgomp/env.c
+@@ -2224,7 +2224,8 @@ initialize_env (void)
+   none = gomp_get_initial_icv_item (GOMP_DEVICE_NUM_FOR_NO_SUFFIX);
+   initialize_icvs (&none->icvs);
+
++  if (environ)
+   for (env = environ; *env != 0; env++)
+     {
+       if (!startswith (*env, "OMP_"))
+ 	continue;


### PR DESCRIPTION
Backport upstream fix https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111413 from GCC14 to GCC13.
The change by itself is huge, but avoiding to to indentation changes it can be summarized to single line change, that we used for thet backport to reduce the risk of patch conflicts. See https://github.com/gcc-mirror/gcc/commit/15345980633c502f0486a2e40e96224f49134130?w=1 for a proof of this.

Fix https://github.com/conda-forge/ctng-compilers-feedstock/issues/114
Fix https://github.com/conda-forge/casadi-feedstock/issues/91


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
