### PR TITLE
add empty build environment to `gcc` to break subdir confusion

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -223,6 +223,7 @@ outputs:
     build:
       skip: true  # [target_platform != cross_target_platform]
     requirements:
+      build:
       host:
         - gcc_impl_{{ target_platform }} {{ gcc_version }}.*
       run:


### PR DESCRIPTION
Follow-up to #133 because the windows builds are [stuck](https://github.com/conda-forge/ctng-compilers-feedstock/pull/133#issuecomment-2196109347).