### PR TITLE
Fix libgomp run_exports and conda-gcc-specs for windows

### DIFF
--- a/recipe/install-conda-specs.sh
+++ b/recipe/install-conda-specs.sh
@@ -20,8 +20,10 @@ if [[ "$cross_target_platform" == "$target_platform" ]]; then
     #   and recorded in the specs file.  It will undergo a prefix replacement when our compiler
     #   package is installed.
     sed -i -e "/\*link_command:/,+1 s+%.*+& %{\!static:-rpath ${PREFIX}/lib -rpath-link ${PREFIX}/lib} -L ${PREFIX}/lib/stubs -L ${PREFIX}/lib+" $specdir/conda.specs
-    # put -disable-new-dtags at the front of the cmdline so that user provided -enable-new-dtags (in %l) can  override it
-    sed -i -e "/\*link_command:/,+1 s+%(linker)+& -disable-new-dtags +" $specdir/conda.specs
+    if [[ "$cross_target_platform" != "win-"* ]]; then
+      # put -disable-new-dtags at the front of the cmdline so that user provided -enable-new-dtags (in %l) can  override it
+      sed -i -e "/\*link_command:/,+1 s+%(linker)+& -disable-new-dtags +" $specdir/conda.specs
+    fi
     # use -idirafter to put the conda "system" includes where /usr/local/include would typically go
     # in a system-packaged non-cross compiler
     sed -i -e "/\*cpp_options:/,+1 s+%.*+& -idirafter ${PREFIX}/include+" $specdir/conda.specs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = gcc_version %}
-{% set build_num = 1 %}
+{% set build_num = 2 %}
 
 {% if gcc_maj_ver is not defined %}
 {% set gcc_maj_ver = 14 %}
@@ -507,6 +507,9 @@ outputs:
       run_exports:
         strong:
           - {{ pin_subpackage("_openmp_mutex", max_pin=None) }}
+          {% if cross_target_platform.startswith("win-") %}
+          - {{ pin_subpackage("libgomp", max_pin=None) }}
+          {% endif %}
     requirements:
       build:
       host:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
