### PR TITLE
bump build number of _openmp_mutex

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -560,7 +560,7 @@ outputs:
     script: install-openmp_impl.sh
     version: {{ openmp_ver }}
     build:
-      string: 2_gnu
+      string: 3_gnu
       skip: true    # [target_platform != cross_target_platform]
       run_exports:
         strong:


### PR DESCRIPTION
I noticed that there hadn't been a new (GNU) `_openmp_mutex` [build](https://anaconda.org/conda-forge/_openmp_mutex/files) since almost 3 years, which is due to the fully static build string it uses
https://github.com/conda-forge/ctng-compilers-feedstock/blob/8da70a056deac8170bd5fbdf93af535dc03c302b/recipe/meta.yaml#L563

Update the version in the build string to pick up changes to that output that have happened since then.