### PR TITLE
Remove obsolete extra channels & a stray symlink

### DIFF
--- a/.ci_support/linux_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_aarch64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/linux_riscv64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/linux_riscv64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.39'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformlinux-64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformlinux-aarch64cross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformlinux-ppc64lecross_target_stdlibsysrootcross_target_stdlib_version2.17gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformlinux-riscv64cross_target_stdlibsysrootcross_target_stdlib_version2.39gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64cross_target_stdlibNonecross_target_stdlib_version0gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/osx_arm64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/win_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver14gcc_version14.4.0.yaml
+++ b/.ci_support/win_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver14gcc_version14.4.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '12'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/win_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
+++ b/.ci_support/win_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver15gcc_version15.3.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '12'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/.ci_support/win_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
+++ b/.ci_support/win_64_cross_target_platformwin-64cross_target_stdlibm2w64-sysrootcross_target_stdlib_version12gcc_maj_ver16gcc_version16.1.0.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 c_stdlib_version:
 - '12'
 channel_sources:
-- conda-forge/label/sysroot-with-crypt,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_cxx_stdlib:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -59,8 +59,6 @@ openmp_ver:
   - 4.5
 libgomp_ver:
   - 1.0.0
-channel_sources:
-  - conda-forge/label/sysroot-with-crypt,conda-forge
 # we could use stdlib("m2w64_c"), but this allows uniform use in setup_compiler.sh
 c_stdlib:          # [win]
   - m2w64-sysroot  # [win]

--- a/recipe/install-gcc.sh
+++ b/recipe/install-gcc.sh
@@ -228,6 +228,11 @@ fi
   
 mkdir -p ${PREFIX}/lib/gcc/${TARGET}/${gcc_version}/
 for name in atomic atomic_asneeded gomp itm quadmath {a,hwa,l,t,ub}san; do
+  if [[ "${HOST}" == *mingw* && "${name}" == "atomic_asneeded" ]]; then
+    # libatomic_asneeded.a (only for v16+) is a symlink itself,
+    # which causes downstream issues on windows; delete it
+    rm ${PREFIX}/lib/lib${name}.a || true
+  fi
   # depending on the order of iteration (and thus file moves), symlinks from one lib to another
   # (e.g. libatomic_asneeded.a -> libatomic.a) might not be valid; allow broken symlinks with -L
   if [[ -e "${PREFIX}/lib/lib${name}.a" || -L "${PREFIX}/lib/lib${name}.a" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -236,6 +236,7 @@ outputs:
         - test -f ${PREFIX}/lib/gcc/{{ TARGET }}/{{ gcc_version }}/libgcc_s.a
         - test -f ${PREFIX}/lib/gcc/{{ TARGET }}/{{ gcc_version }}/libquadmath.a
         - test -f ${PREFIX}/lib/gcc/{{ TARGET }}/{{ gcc_version }}/libgomp.a
+        - test ! -f ${PREFIX}/lib/gcc/{{ TARGET }}/{{ gcc_version }}/libatomic_asneeded.a   # [win]
         {% endif %}
         - test -f ${PREFIX}/lib/gcc/{{ TARGET }}/{{ gcc_version }}/libgomp.spec
     about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = gcc_version %}
-{% set build_num = 0 %}
+{% set build_num = 1 %}
 
 {% if gcc_maj_ver is not defined %}
 {% set gcc_maj_ver = 15 %}

--- a/recipe/setup_compiler.sh
+++ b/recipe/setup_compiler.sh
@@ -41,7 +41,7 @@ if [[ ! -d ${SRC_DIR}/cf-compilers ]]; then
         "make"
       )
     fi
-    conda create -p ${CF_PREFIX} -c conda-forge/label/gcc-experimental -c conda-forge --use-local --yes --quiet \
+    conda create -p ${CF_PREFIX} -c conda-forge --use-local --yes --quiet \
       "gcc_impl_${build_platform}" \
       "gxx_impl_${build_platform}" \
       "gfortran_impl_${build_platform}" \

--- a/recipe/setup_compiler.sh
+++ b/recipe/setup_compiler.sh
@@ -41,8 +41,7 @@ if [[ ! -d ${SRC_DIR}/cf-compilers ]]; then
         "make"
       )
     fi
-    # Remove conda-forge/label/sysroot-with-crypt when GCC < 14 is dropped
-    conda create -p ${CF_PREFIX} -c conda-forge/label/gcc-experimental -c conda-forge/label/sysroot-with-crypt -c conda-forge --use-local --yes --quiet \
+    conda create -p ${CF_PREFIX} -c conda-forge/label/gcc-experimental -c conda-forge --use-local --yes --quiet \
       "gcc_impl_${build_platform}" \
       "gxx_impl_${build_platform}" \
       "gfortran_impl_${build_platform}" \
@@ -54,13 +53,13 @@ if [[ ! -d ${SRC_DIR}/cf-compilers ]]; then
       ${extra_pkgs[@]}
 
     if [[ "${TARGET}" == *darwin* ]]; then
-      CONDA_OVERRIDE_OSX=15.5 CONDA_SUBDIR="${cross_target_platform}" conda create -p $SRC_DIR/cf-compilers-target -c conda-forge/label/sysroot-with-crypt -c conda-forge --use-local --yes --quiet libcxx-devel
+      CONDA_OVERRIDE_OSX=15.5 CONDA_SUBDIR="${cross_target_platform}" conda create -p $SRC_DIR/cf-compilers-target -c conda-forge --use-local --yes --quiet libcxx-devel
       mkdir -p ${CF_PREFIX}/${TARGET}/lib
       ln -sf $SRC_DIR/cf-compilers-target/lib/libc++* ${CF_PREFIX}/${TARGET}/lib
 
     fi
     if [[ "${HOST}" == *darwin* && "${HOST}" != "${TARGET}" ]]; then
-      CONDA_OVERRIDE_OSX=15.5 CONDA_SUBDIR="${target_platform}" conda create -p $SRC_DIR/cf-compilers-host -c conda-forge/label/sysroot-with-crypt -c conda-forge --use-local --yes --quiet libcxx-devel
+      CONDA_OVERRIDE_OSX=15.5 CONDA_SUBDIR="${target_platform}" conda create -p $SRC_DIR/cf-compilers-host -c conda-forge --use-local --yes --quiet libcxx-devel
       mkdir -p ${CF_PREFIX}/${HOST}/lib
       ln -sf $SRC_DIR/cf-compilers-host/lib/libc++* ${CF_PREFIX}/${HOST}/lib
     fi


### PR DESCRIPTION
Follow-up to #211, there were some failure in the 2nd stage builds because of some old `gcc_impl_osx-64` [builds](https://anaconda.org/channels/conda-forge/packages/gcc_impl_osx-64/files?labels=gcc-experimental) under the `gcc-experimental` label which now clash with the current builds here in terms of channel priority; while we're at it, remove `sysroot-with-crypt`, which isn't needed anymore after we've dropped GCC 13, c.f.
https://github.com/conda-forge/ctng-compilers-feedstock/blob/f29301aeb71091e4b4a215a22c9e56d2a8378df1/recipe/setup_compiler.sh#L44
Finally, drop a symlink that causes failures in https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/200 (due to https://github.com/conda-forge/conda-smithy/issues/2638)